### PR TITLE
Add Ed25519 quote signature verification and integration into SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ const quoteRequest: QuoteRequest = {
 const quote = await OneClickService.getQuote(quoteRequest);
 ```
 
+
+## Quote Signature Verification
+
+`OneClickService.getQuote()` automatically verifies the Ed25519 signature returned by the 1Click quote endpoint before resolving. If the signature is missing, malformed, or does not match the canonical quote payload, the returned promise rejects with `QuoteSignatureVerificationError`.
+
+The SDK also exports helper functions for applications that persist quotes and want to re-check them later:
+
+```typescript
+import {
+  QuoteSignatureVerificationError,
+  verifyQuoteResponseSignature,
+  verifyQuoteResponseOrThrow,
+} from '@defuse-protocol/one-click-sdk-typescript';
+
+const isAuthentic = verifyQuoteResponseSignature(savedQuote);
+verifyQuoteResponseOrThrow(savedQuote);
+```
+
+Signature verification is a defense-in-depth authenticity check. Applications should still use TLS, authenticate the API endpoint, validate every quote field, and enforce their own risk controls.
+
 ## API Methods
 
 [See official API docs](https://docs.near-intents.org/near-intents/integration/distribution-channels/1click-api) for more info on endpoints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.6.8",
-        "form-data": "^4.0.0"
+        "form-data": "^4.0.0",
+        "js-sha256": "^0.11.1",
+        "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
         "openapi-typescript-codegen": "^0.29.0",
@@ -1409,6 +1411,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2092,6 +2100,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/typescript": {
       "version": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "fetch-api": "curl -o openapi.yaml https://1click.chaindefuser.com/docs/v0/openapi.yaml",
-    "generate": "openapi --input openapi.yaml --output ./src --client axios",
+    "generate": "pnpm run generate:openapi && node scripts/apply-customizations.cjs",
     "generate:fresh": "pnpm run fetch-api && pnpm run generate",
     "clean": "rm -rf dist node_modules",
     "prepublishOnly": "pnpm run clean && pnpm install && pnpm run generate:fresh && pnpm run build",
     "prepack": "pnpm run build",
-    "release": "pnpm run prepublishOnly && pnpm publish --access public"
+    "release": "pnpm run prepublishOnly && pnpm publish --access public",
+    "generate:openapi": "openapi --input openapi.yaml --output ./src --client axios",
+    "test:e2e": "pnpm build && node scripts/test-generation-and-verification.cjs"
   },
   "repository": {
     "type": "git",
@@ -56,7 +58,9 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
-    "form-data": "^4.0.0"
+    "form-data": "^4.0.0",
+    "js-sha256": "^0.11.1",
+    "tweetnacl": "^1.0.3"
   },
   "packageManager": "pnpm@8.15.4",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   form-data:
     specifier: ^4.0.0
     version: 4.0.2
+  js-sha256:
+    specifier: ^0.11.1
+    version: 0.11.1
+  tweetnacl:
+    specifier: ^1.0.3
+    version: 1.0.3
 
 devDependencies:
   openapi-typescript-codegen:
@@ -868,6 +874,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /js-sha256@0.11.1:
+    resolution: {integrity: sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==}
+    dev: false
+
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1228,6 +1238,10 @@ packages:
       - tsx
       - yaml
     dev: true
+
+  /tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+    dev: false
 
   /typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}

--- a/scripts/apply-customizations.cjs
+++ b/scripts/apply-customizations.cjs
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const quoteSignatureTemplate = path.join(__dirname, 'templates', 'quoteSignature.ts');
+const quoteSignatureTarget = path.join(repoRoot, 'src', 'quoteSignature.ts');
+const servicePath = path.join(repoRoot, 'src', 'services', 'OneClickService.ts');
+const indexPath = path.join(repoRoot, 'src', 'index.ts');
+
+fs.mkdirSync(path.dirname(quoteSignatureTarget), { recursive: true });
+fs.copyFileSync(quoteSignatureTemplate, quoteSignatureTarget);
+
+let service = fs.readFileSync(servicePath, 'utf8');
+if (!service.includes("../quoteSignature")) {
+  service = service.replace(
+    "import { request as __request } from '../core/request';\n",
+    "import { request as __request } from '../core/request';\nimport { withQuoteSignatureVerification } from '../quoteSignature';\n",
+  );
+}
+
+const getQuoteReturn = "        return __request(OpenAPI, {\n            method: 'POST',\n            url: '/v0/quote',";
+if (service.includes(getQuoteReturn) && !service.includes('return withQuoteSignatureVerification(__request(OpenAPI, {')) {
+  service = service.replace(getQuoteReturn, "        return withQuoteSignatureVerification(__request(OpenAPI, {\n            method: 'POST',\n            url: '/v0/quote',");
+  service = service.replace(
+    "            },\n        });\n    }\n    /**\n     * Check swap execution status",
+    "            },\n        }));\n    }\n    /**\n     * Check swap execution status",
+  );
+}
+fs.writeFileSync(servicePath, service);
+
+let index = fs.readFileSync(indexPath, 'utf8');
+const quoteSignatureExport = "export { QuoteSignatureVerificationError, getCanonicalQuoteHash, getCanonicalQuotePayload, verifyQuoteResponseOrThrow, verifyQuoteResponseSignature } from './quoteSignature';\n";
+if (!index.includes("from './quoteSignature'")) {
+  index = index.replace("export type { OpenAPIConfig } from './core/OpenAPI';\n", "export type { OpenAPIConfig } from './core/OpenAPI';\n" + quoteSignatureExport);
+}
+fs.writeFileSync(indexPath, index);

--- a/scripts/apply-customizations.cjs
+++ b/scripts/apply-customizations.cjs
@@ -7,30 +7,52 @@ const quoteSignatureTarget = path.join(repoRoot, 'src', 'quoteSignature.ts');
 const servicePath = path.join(repoRoot, 'src', 'services', 'OneClickService.ts');
 const indexPath = path.join(repoRoot, 'src', 'index.ts');
 
+const replaceOrThrow = (source, search, replacement, description) => {
+  if (!source.includes(search)) {
+    throw new Error(`Unable to apply 1Click SDK customization: ${description}`);
+  }
+  return source.replace(search, replacement);
+};
+
 fs.mkdirSync(path.dirname(quoteSignatureTarget), { recursive: true });
 fs.copyFileSync(quoteSignatureTemplate, quoteSignatureTarget);
 
 let service = fs.readFileSync(servicePath, 'utf8');
 if (!service.includes("../quoteSignature")) {
-  service = service.replace(
+  service = replaceOrThrow(
+    service,
     "import { request as __request } from '../core/request';\n",
     "import { request as __request } from '../core/request';\nimport { withQuoteSignatureVerification } from '../quoteSignature';\n",
+    'could not find generated request import in OneClickService',
   );
 }
 
-const getQuoteReturn = "        return __request(OpenAPI, {\n            method: 'POST',\n            url: '/v0/quote',";
-if (service.includes(getQuoteReturn) && !service.includes('return withQuoteSignatureVerification(__request(OpenAPI, {')) {
-  service = service.replace(getQuoteReturn, "        return withQuoteSignatureVerification(__request(OpenAPI, {\n            method: 'POST',\n            url: '/v0/quote',");
-  service = service.replace(
-    "            },\n        });\n    }\n    /**\n     * Check swap execution status",
-    "            },\n        }));\n    }\n    /**\n     * Check swap execution status",
+if (!service.includes('return withQuoteSignatureVerification(__request(OpenAPI, {')) {
+  service = replaceOrThrow(
+    service,
+    "        return __request(OpenAPI, {\n            method: 'POST',\n            url: '/v0/quote',",
+    "        return withQuoteSignatureVerification(__request(OpenAPI, {\n            method: 'POST',\n            url: '/v0/quote',",
+    'could not find generated getQuote request call',
   );
+  const wrappedGetQuoteIndex = service.indexOf('return withQuoteSignatureVerification(__request(OpenAPI, {');
+  const requestTerminatorIndex = service.indexOf("        });\n    }", wrappedGetQuoteIndex);
+  if (requestTerminatorIndex === -1) {
+    throw new Error('Unable to apply 1Click SDK customization: could not find generated getQuote request terminator');
+  }
+  service = service.slice(0, requestTerminatorIndex)
+    + "        }));\n    }"
+    + service.slice(requestTerminatorIndex + "        });\n    }".length);
 }
 fs.writeFileSync(servicePath, service);
 
 let index = fs.readFileSync(indexPath, 'utf8');
 const quoteSignatureExport = "export { QuoteSignatureVerificationError, getCanonicalQuoteHash, getCanonicalQuotePayload, verifyQuoteResponseOrThrow, verifyQuoteResponseSignature } from './quoteSignature';\n";
-if (!index.includes("from './quoteSignature'")) {
-  index = index.replace("export type { OpenAPIConfig } from './core/OpenAPI';\n", "export type { OpenAPIConfig } from './core/OpenAPI';\n" + quoteSignatureExport);
+if (!index.includes(quoteSignatureExport)) {
+  index = replaceOrThrow(
+    index,
+    "export type { OpenAPIConfig } from './core/OpenAPI';\n",
+    "export type { OpenAPIConfig } from './core/OpenAPI';\n" + quoteSignatureExport,
+    'could not find OpenAPIConfig export insertion point',
+  );
 }
 fs.writeFileSync(indexPath, index);

--- a/scripts/templates/quoteSignature.ts
+++ b/scripts/templates/quoteSignature.ts
@@ -1,0 +1,134 @@
+import { sha256 } from 'js-sha256';
+import nacl from 'tweetnacl';
+
+import { CancelablePromise } from './core/CancelablePromise';
+import type { QuoteResponse } from './models/QuoteResponse';
+
+const ONE_CLICK_PUBLIC_KEY = 'ed25519:reYaWhvwu8Jzo3WUM3zhn6VrhuMEF4eADL17qtRVifc';
+const SIGNATURE_PREFIX = 'ed25519:';
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const textEncoder = new TextEncoder();
+
+export class QuoteSignatureVerificationError extends Error {
+    public readonly quoteResponse: QuoteResponse;
+
+    constructor(message: string, quoteResponse: QuoteResponse) {
+        super(message);
+        this.name = 'QuoteSignatureVerificationError';
+        this.quoteResponse = quoteResponse;
+    }
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue | undefined };
+
+const isPlainObject = (value: unknown): value is Record<string, JsonValue | undefined> => {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const stableStringify = (value: JsonValue): string => {
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+    }
+
+    if (isPlainObject(value)) {
+        return `{${Object.keys(value)
+            .filter((key) => value[key] !== undefined)
+            .sort()
+            .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key] as JsonValue)}`)
+            .join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+};
+
+const decodeBase58 = (value: string): Uint8Array => {
+    const bytes = [0];
+
+    for (const char of value) {
+        const index = BASE58_ALPHABET.indexOf(char);
+        if (index === -1) {
+            throw new Error(`Invalid base58 character: ${char}`);
+        }
+
+        let carry = index;
+        for (let i = 0; i < bytes.length; i += 1) {
+            carry += bytes[i] * 58;
+            bytes[i] = carry & 0xff;
+            carry >>= 8;
+        }
+
+        while (carry > 0) {
+            bytes.push(carry & 0xff);
+            carry >>= 8;
+        }
+    }
+
+    for (const char of value) {
+        if (char !== '1') {
+            break;
+        }
+        bytes.push(0);
+    }
+
+    return new Uint8Array(bytes.reverse());
+};
+
+const getEd25519Value = (value: string, fieldName: string): string => {
+    if (!value.startsWith(SIGNATURE_PREFIX)) {
+        throw new Error(`${fieldName} must start with ${SIGNATURE_PREFIX}`);
+    }
+
+    return value.slice(SIGNATURE_PREFIX.length);
+};
+
+export const getCanonicalQuotePayload = (quoteResponse: QuoteResponse): string => {
+    return `{${[
+        `${JSON.stringify('quoteRequest')}:${stableStringify(quoteResponse.quoteRequest as JsonValue)}`,
+        `${JSON.stringify('quote')}:${stableStringify(quoteResponse.quote as JsonValue)}`,
+        `${JSON.stringify('timestamp')}:${stableStringify(quoteResponse.timestamp as JsonValue)}`,
+    ].join(',')}}`;
+};
+
+export const getCanonicalQuoteHash = (quoteResponse: QuoteResponse): string => {
+    return sha256(getCanonicalQuotePayload(quoteResponse));
+};
+
+const verifyQuoteResponseSignatureStrict = (quoteResponse: QuoteResponse): boolean => {
+    const signature = decodeBase58(getEd25519Value(quoteResponse.signature, 'Quote signature'));
+    const publicKey = decodeBase58(getEd25519Value(ONE_CLICK_PUBLIC_KEY, '1Click public key'));
+    const message = textEncoder.encode(getCanonicalQuoteHash(quoteResponse));
+
+    return nacl.sign.detached.verify(message, signature, publicKey);
+};
+
+export const verifyQuoteResponseSignature = (quoteResponse: QuoteResponse): boolean => {
+    try {
+        return verifyQuoteResponseSignatureStrict(quoteResponse);
+    } catch {
+        return false;
+    }
+};
+
+export const verifyQuoteResponseOrThrow = (quoteResponse: QuoteResponse): QuoteResponse => {
+    if (!verifyQuoteResponseSignature(quoteResponse)) {
+        throw new QuoteSignatureVerificationError('1Click quote signature verification failed', quoteResponse);
+    }
+
+    return quoteResponse;
+};
+
+export const withQuoteSignatureVerification = (promise: CancelablePromise<QuoteResponse>): CancelablePromise<QuoteResponse> => {
+    return new CancelablePromise<QuoteResponse>((resolve, reject, onCancel) => {
+        onCancel(() => promise.cancel());
+
+        promise
+            .then((quoteResponse) => {
+                try {
+                    resolve(verifyQuoteResponseOrThrow(quoteResponse));
+                } catch (error) {
+                    reject(error);
+                }
+            })
+            .catch(reject);
+    });
+};

--- a/scripts/test-generation-and-verification.cjs
+++ b/scripts/test-generation-and-verification.cjs
@@ -132,8 +132,10 @@ const assertGeneratedQuoteClientVerifiesSignatures = async () => {
     generateCustomizedClient(tempRoot, publicKey);
 
     const service = fs.readFileSync(path.join(tempRoot, 'src/services/OneClickService.ts'), 'utf8');
+    const index = fs.readFileSync(path.join(tempRoot, 'src/index.ts'), 'utf8');
     assert.match(service, /import \{ withQuoteSignatureVerification \} from '\.\.\/quoteSignature';/);
     assert.match(service, /return withQuoteSignatureVerification\(__request\(OpenAPI, \{/);
+    assert.match(index, /verifyQuoteResponseSignature/);
 
     transpileGeneratedClient(path.join(tempRoot, 'src'), path.join(tempRoot, 'dist'));
 

--- a/scripts/test-generation-and-verification.cjs
+++ b/scripts/test-generation-and-verification.cjs
@@ -1,0 +1,187 @@
+const assert = require('assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const nacl = require('tweetnacl');
+const ts = require('typescript');
+
+const repoRoot = path.resolve(__dirname, '..');
+const base58Alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const textEncoder = new TextEncoder();
+
+const encodeBase58 = (input) => {
+  const digits = [0];
+
+  for (const byte of input) {
+    let carry = byte;
+    for (let i = 0; i < digits.length; i += 1) {
+      carry += digits[i] << 8;
+      digits[i] = carry % 58;
+      carry = Math.floor(carry / 58);
+    }
+
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = Math.floor(carry / 58);
+    }
+  }
+
+  for (const byte of input) {
+    if (byte !== 0) break;
+    digits.push(0);
+  }
+
+  return digits.reverse().map((digit) => base58Alphabet[digit]).join('');
+};
+
+const transpileGeneratedClient = (srcRoot, distRoot) => {
+  for (const entry of fs.readdirSync(srcRoot, { withFileTypes: true })) {
+    const sourcePath = path.join(srcRoot, entry.name);
+    const outputPath = path.join(distRoot, entry.name);
+
+    if (entry.isDirectory()) {
+      transpileGeneratedClient(sourcePath, outputPath);
+      continue;
+    }
+
+    if (!entry.name.endsWith('.ts')) {
+      continue;
+    }
+
+    const output = ts.transpileModule(fs.readFileSync(sourcePath, 'utf8'), {
+      compilerOptions: {
+        esModuleInterop: true,
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2020,
+      },
+    });
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath.replace(/\.ts$/, '.js'), output.outputText);
+  }
+};
+
+const generateCustomizedClient = (tempRoot, publicKey) => {
+  fs.cpSync(path.join(repoRoot, 'scripts'), path.join(tempRoot, 'scripts'), { recursive: true });
+  execFileSync(
+    'pnpm',
+    [
+      'exec',
+      'openapi',
+      '--input',
+      path.join(repoRoot, 'test/fixtures/openapi.quote.yaml'),
+      '--output',
+      path.join(tempRoot, 'src'),
+      '--client',
+      'axios',
+    ],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  execFileSync(process.execPath, [path.join(tempRoot, 'scripts/apply-customizations.cjs')], { stdio: 'inherit' });
+
+  const quoteSignaturePath = path.join(tempRoot, 'src/quoteSignature.ts');
+  fs.writeFileSync(
+    quoteSignaturePath,
+    fs.readFileSync(quoteSignaturePath, 'utf8').replace(
+      'ed25519:reYaWhvwu8Jzo3WUM3zhn6VrhuMEF4eADL17qtRVifc',
+      publicKey,
+    ),
+  );
+};
+
+const createQuoteResponse = () => ({
+  correlationId: 'correlation-id',
+  timestamp: '2026-06-01T00:00:00.000Z',
+  signature: '',
+  quoteRequest: {
+    dry: false,
+    swapType: 'EXACT_INPUT',
+    slippageTolerance: 100,
+    originAsset: 'nep141:origin.test',
+    depositType: 'ORIGIN_CHAIN',
+    destinationAsset: 'nep141:destination.test',
+    amount: '1000000',
+    refundTo: 'refund-address',
+    refundType: 'ORIGIN_CHAIN',
+    recipient: 'recipient-address',
+    recipientType: 'DESTINATION_CHAIN',
+    deadline: '2026-06-01T01:00:00.000Z',
+  },
+  quote: {
+    depositAddress: 'deposit-address',
+    amountIn: '1000000',
+    amountInFormatted: '1',
+    amountInUsd: '1.00',
+    minAmountIn: '1000000',
+    amountOut: '990000',
+    amountOutFormatted: '0.99',
+    amountOutUsd: '0.99',
+    minAmountOut: '980000',
+    timeEstimate: 60,
+  },
+});
+
+const assertGeneratedQuoteClientVerifiesSignatures = async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'one-click-sdk-generation-'));
+
+  try {
+    const keyPair = nacl.sign.keyPair();
+    const publicKey = `ed25519:${encodeBase58(keyPair.publicKey)}`;
+    fs.symlinkSync(path.join(repoRoot, 'node_modules'), path.join(tempRoot, 'node_modules'), 'dir');
+    generateCustomizedClient(tempRoot, publicKey);
+
+    const service = fs.readFileSync(path.join(tempRoot, 'src/services/OneClickService.ts'), 'utf8');
+    assert.match(service, /import \{ withQuoteSignatureVerification \} from '\.\.\/quoteSignature';/);
+    assert.match(service, /return withQuoteSignatureVerification\(__request\(OpenAPI, \{/);
+
+    transpileGeneratedClient(path.join(tempRoot, 'src'), path.join(tempRoot, 'dist'));
+
+    const { getCanonicalQuoteHash, QuoteSignatureVerificationError } = require(path.join(tempRoot, 'dist/quoteSignature.js'));
+    const { OneClickService } = require(path.join(tempRoot, 'dist/services/OneClickService.js'));
+    const axios = require('axios');
+    const originalRequest = axios.request;
+    const quoteResponse = createQuoteResponse();
+    quoteResponse.signature = `ed25519:${encodeBase58(
+      nacl.sign.detached(textEncoder.encode(getCanonicalQuoteHash(quoteResponse)), keyPair.secretKey),
+    )}`;
+
+    try {
+      axios.request = async () => ({
+        data: quoteResponse,
+        headers: {},
+        status: 200,
+        statusText: 'OK',
+      });
+      assert.deepEqual(await OneClickService.getQuote(quoteResponse.quoteRequest), quoteResponse);
+
+      axios.request = async () => ({
+        data: {
+          ...quoteResponse,
+          quote: {
+            ...quoteResponse.quote,
+            amountOut: '1',
+          },
+        },
+        headers: {},
+        status: 200,
+        statusText: 'OK',
+      });
+      await assert.rejects(
+        () => OneClickService.getQuote(quoteResponse.quoteRequest),
+        QuoteSignatureVerificationError,
+      );
+    } finally {
+      axios.request = originalRequest;
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+};
+
+assertGeneratedQuoteClientVerifiesSignatures()
+  .then(() => console.log('API client generation and quote verification e2e test passed'))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { ApiError } from './core/ApiError';
 export { CancelablePromise, CancelError } from './core/CancelablePromise';
 export { OpenAPI } from './core/OpenAPI';
 export type { OpenAPIConfig } from './core/OpenAPI';
+export { QuoteSignatureVerificationError, getCanonicalQuoteHash, getCanonicalQuotePayload, verifyQuoteResponseOrThrow, verifyQuoteResponseSignature } from './quoteSignature';
 
 export { AnyInputQuoteWithdrawal } from './models/AnyInputQuoteWithdrawal';
 export type { AppFee } from './models/AppFee';

--- a/src/quoteSignature.ts
+++ b/src/quoteSignature.ts
@@ -1,0 +1,134 @@
+import { sha256 } from 'js-sha256';
+import nacl from 'tweetnacl';
+
+import { CancelablePromise } from './core/CancelablePromise';
+import type { QuoteResponse } from './models/QuoteResponse';
+
+const ONE_CLICK_PUBLIC_KEY = 'ed25519:reYaWhvwu8Jzo3WUM3zhn6VrhuMEF4eADL17qtRVifc';
+const SIGNATURE_PREFIX = 'ed25519:';
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const textEncoder = new TextEncoder();
+
+export class QuoteSignatureVerificationError extends Error {
+    public readonly quoteResponse: QuoteResponse;
+
+    constructor(message: string, quoteResponse: QuoteResponse) {
+        super(message);
+        this.name = 'QuoteSignatureVerificationError';
+        this.quoteResponse = quoteResponse;
+    }
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue | undefined };
+
+const isPlainObject = (value: unknown): value is Record<string, JsonValue | undefined> => {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const stableStringify = (value: JsonValue): string => {
+    if (Array.isArray(value)) {
+        return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+    }
+
+    if (isPlainObject(value)) {
+        return `{${Object.keys(value)
+            .filter((key) => value[key] !== undefined)
+            .sort()
+            .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key] as JsonValue)}`)
+            .join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+};
+
+const decodeBase58 = (value: string): Uint8Array => {
+    const bytes = [0];
+
+    for (const char of value) {
+        const index = BASE58_ALPHABET.indexOf(char);
+        if (index === -1) {
+            throw new Error(`Invalid base58 character: ${char}`);
+        }
+
+        let carry = index;
+        for (let i = 0; i < bytes.length; i += 1) {
+            carry += bytes[i] * 58;
+            bytes[i] = carry & 0xff;
+            carry >>= 8;
+        }
+
+        while (carry > 0) {
+            bytes.push(carry & 0xff);
+            carry >>= 8;
+        }
+    }
+
+    for (const char of value) {
+        if (char !== '1') {
+            break;
+        }
+        bytes.push(0);
+    }
+
+    return new Uint8Array(bytes.reverse());
+};
+
+const getEd25519Value = (value: string, fieldName: string): string => {
+    if (!value.startsWith(SIGNATURE_PREFIX)) {
+        throw new Error(`${fieldName} must start with ${SIGNATURE_PREFIX}`);
+    }
+
+    return value.slice(SIGNATURE_PREFIX.length);
+};
+
+export const getCanonicalQuotePayload = (quoteResponse: QuoteResponse): string => {
+    return `{${[
+        `${JSON.stringify('quoteRequest')}:${stableStringify(quoteResponse.quoteRequest as JsonValue)}`,
+        `${JSON.stringify('quote')}:${stableStringify(quoteResponse.quote as JsonValue)}`,
+        `${JSON.stringify('timestamp')}:${stableStringify(quoteResponse.timestamp as JsonValue)}`,
+    ].join(',')}}`;
+};
+
+export const getCanonicalQuoteHash = (quoteResponse: QuoteResponse): string => {
+    return sha256(getCanonicalQuotePayload(quoteResponse));
+};
+
+const verifyQuoteResponseSignatureStrict = (quoteResponse: QuoteResponse): boolean => {
+    const signature = decodeBase58(getEd25519Value(quoteResponse.signature, 'Quote signature'));
+    const publicKey = decodeBase58(getEd25519Value(ONE_CLICK_PUBLIC_KEY, '1Click public key'));
+    const message = textEncoder.encode(getCanonicalQuoteHash(quoteResponse));
+
+    return nacl.sign.detached.verify(message, signature, publicKey);
+};
+
+export const verifyQuoteResponseSignature = (quoteResponse: QuoteResponse): boolean => {
+    try {
+        return verifyQuoteResponseSignatureStrict(quoteResponse);
+    } catch {
+        return false;
+    }
+};
+
+export const verifyQuoteResponseOrThrow = (quoteResponse: QuoteResponse): QuoteResponse => {
+    if (!verifyQuoteResponseSignature(quoteResponse)) {
+        throw new QuoteSignatureVerificationError('1Click quote signature verification failed', quoteResponse);
+    }
+
+    return quoteResponse;
+};
+
+export const withQuoteSignatureVerification = (promise: CancelablePromise<QuoteResponse>): CancelablePromise<QuoteResponse> => {
+    return new CancelablePromise<QuoteResponse>((resolve, reject, onCancel) => {
+        onCancel(() => promise.cancel());
+
+        promise
+            .then((quoteResponse) => {
+                try {
+                    resolve(verifyQuoteResponseOrThrow(quoteResponse));
+                } catch (error) {
+                    reject(error);
+                }
+            })
+            .catch(reject);
+    });
+};

--- a/src/services/OneClickService.ts
+++ b/src/services/OneClickService.ts
@@ -12,6 +12,7 @@ import type { TokenResponse } from '../models/TokenResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
+import { withQuoteSignatureVerification } from '../quoteSignature';
 export class OneClickService {
     /**
      * Get supported tokens
@@ -43,7 +44,7 @@ export class OneClickService {
     public static getQuote(
         requestBody: QuoteRequest,
     ): CancelablePromise<QuoteResponse> {
-        return __request(OpenAPI, {
+        return withQuoteSignatureVerification(__request(OpenAPI, {
             method: 'POST',
             url: '/v0/quote',
             body: requestBody,
@@ -52,7 +53,7 @@ export class OneClickService {
                 400: `Bad Request - Invalid input data`,
                 401: `Unauthorized - JWT token is invalid`,
             },
-        });
+        }));
     }
     /**
      * Check swap execution status

--- a/test/fixtures/openapi.quote.yaml
+++ b/test/fixtures/openapi.quote.yaml
@@ -1,0 +1,124 @@
+openapi: 3.0.3
+info:
+  title: 1Click Quote Fixture
+  version: 0.0.0
+servers:
+  - url: https://1click.example.test
+paths:
+  /v0/quote:
+    post:
+      tags:
+        - OneClick
+      operationId: getQuote
+      summary: Request a swap quote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuoteRequest'
+      responses:
+        '200':
+          description: Quote response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuoteResponse'
+components:
+  schemas:
+    QuoteRequest:
+      type: object
+      required:
+        - dry
+        - swapType
+        - slippageTolerance
+        - originAsset
+        - depositType
+        - destinationAsset
+        - amount
+        - refundTo
+        - refundType
+        - recipient
+        - recipientType
+        - deadline
+      properties:
+        dry:
+          type: boolean
+        swapType:
+          type: string
+          enum: [EXACT_INPUT]
+        slippageTolerance:
+          type: number
+        originAsset:
+          type: string
+        depositType:
+          type: string
+          enum: [ORIGIN_CHAIN]
+        destinationAsset:
+          type: string
+        amount:
+          type: string
+        refundTo:
+          type: string
+        refundType:
+          type: string
+          enum: [ORIGIN_CHAIN]
+        recipient:
+          type: string
+        recipientType:
+          type: string
+          enum: [DESTINATION_CHAIN]
+        deadline:
+          type: string
+    Quote:
+      type: object
+      required:
+        - amountIn
+        - amountInFormatted
+        - amountInUsd
+        - minAmountIn
+        - amountOut
+        - amountOutFormatted
+        - amountOutUsd
+        - minAmountOut
+        - timeEstimate
+      properties:
+        depositAddress:
+          type: string
+        amountIn:
+          type: string
+        amountInFormatted:
+          type: string
+        amountInUsd:
+          type: string
+        minAmountIn:
+          type: string
+        amountOut:
+          type: string
+        amountOutFormatted:
+          type: string
+        amountOutUsd:
+          type: string
+        minAmountOut:
+          type: string
+        timeEstimate:
+          type: number
+    QuoteResponse:
+      type: object
+      required:
+        - correlationId
+        - timestamp
+        - signature
+        - quoteRequest
+        - quote
+      properties:
+        correlationId:
+          type: string
+        timestamp:
+          type: string
+        signature:
+          type: string
+        quoteRequest:
+          $ref: '#/components/schemas/QuoteRequest'
+        quote:
+          $ref: '#/components/schemas/Quote'


### PR DESCRIPTION
### Motivation
- Ensure authenticity of quotes returned by the 1Click API by verifying Ed25519 signatures returned with quote responses.
- Provide helper utilities so applications can re-check persisted quotes and fail early on tampering.
- Integrate verification into the generated client so `getQuote` automatically enforces signature checks as defense-in-depth.

### Description
- Add `src/quoteSignature.ts` implementing canonical payload/hash, base58 decoding, Ed25519 verification using `js-sha256` and `tweetnacl`, and helper exports `verifyQuoteResponseSignature`, `verifyQuoteResponseOrThrow`, `getCanonicalQuotePayload`, `getCanonicalQuoteHash`, and `withQuoteSignatureVerification`.
- Wrap `OneClickService.getQuote` to call `withQuoteSignatureVerification(...)` so quote responses are verified before resolving, and export verification helpers from `src/index.ts`.
- Add generation automation `scripts/apply-customizations.cjs` and template `scripts/templates/quoteSignature.ts` to inject verification into generated clients, plus a fixture `test/fixtures/openapi.quote.yaml` to exercise generation.
- Add an end-to-end generation/verification test `scripts/test-generation-and-verification.cjs` and a new `test:e2e` script in `package.json`, and add runtime dependencies `js-sha256` and `tweetnacl` with corresponding lockfile updates.
- Update `README.md` with a `Quote Signature Verification` section documenting automatic verification and exported helpers.

### Testing
- Added an automated e2e test `scripts/test-generation-and-verification.cjs` that generates a customized client, injects a test keypair, transpiles the generated code, and asserts successful verification and failure on tampering.
- Executed the end-to-end test via `pnpm run test:e2e` (which runs `pnpm build` and `node scripts/test-generation-and-verification.cjs`), and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1d5fee4cf0832c95d488e7b1de6a7a)