### PR TITLE
chore: create PR on release with newly generated client

### DIFF
--- a/.github/workflows/generate-and-publish.yml
+++ b/.github/workflows/generate-and-publish.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -42,6 +43,7 @@ jobs:
         if: steps.get-version.outputs.version != ''
         env:
           API_VERSION: ${{ steps.get-version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           chmod +x ./scripts/regenerate-and-publish.sh
           ./scripts/regenerate-and-publish.sh

--- a/scripts/regenerate-and-publish.sh
+++ b/scripts/regenerate-and-publish.sh
@@ -24,10 +24,15 @@ echo "Building the SDK..."
 npm install
 npm run build
 
-# Commit all changes before publishing
+# Commit all changes before publishing.
+# `main` is protected by a ruleset requiring every change to arrive via a PR,
+# so we commit onto a dedicated release branch instead of onto main directly.
 echo "Committing changes..."
 git config user.email "action@github.com"
 git config user.name "GitHub Action"
+
+RELEASE_BRANCH="release/${VERSION_NUMBER}"
+git checkout -b "${RELEASE_BRANCH}"
 git add .
 git commit -m "Release: ${VERSION_NUMBER} version" || echo "No changes to commit"
 
@@ -35,8 +40,12 @@ git commit -m "Release: ${VERSION_NUMBER} version" || echo "No changes to commit
 echo "Publishing to npm..."
 npm publish --access public
 
-# Push changes to the repository
-echo "Pushing changes to remote..."
-git push
+# Open a PR for the release branch and let GitHub merge it automatically once
+# the ruleset's requirements are met. We push the branch (allowed) rather than
+# main (rejected), then rely on auto-merge to land the commit on main.
+echo "Opening release PR..."
+git push -u origin "${RELEASE_BRANCH}"
+gh pr create --base main --head "${RELEASE_BRANCH}" --fill
+gh pr merge --auto --squash "${RELEASE_BRANCH}"
 
 echo "TypeScript SDK regeneration process completed for API version: ${VERSION_NUMBER}"


### PR DESCRIPTION
Main branch is protected, so the release script needs to create PR for the updated client instead of pushing directly to main.